### PR TITLE
Bugfix: if `date` is set but not `humandate` in a post

### DIFF
--- a/_layouts/default.liquid
+++ b/_layouts/default.liquid
@@ -46,7 +46,7 @@
             {%- if title != "" %}
             <h1>{{ title }}</h1>
             {%- endif %}
-            {% if date %}
+            {% if humandate %}
               <div class="published-date">
                 <i>Published on {{ humandate }}</i>
               </div>


### PR DESCRIPTION
In the current state, you can have "Published on" with nothing after if you set the date but not the humandate.